### PR TITLE
feat: add mp3_tag_reader and m4a_tag_reader

### DIFF
--- a/songbirdcore/itunes.py
+++ b/songbirdcore/itunes.py
@@ -181,6 +181,77 @@ def mp3ID3Tagger(mp3_path: str, song_tag_data: itunes_api.ItunesApiSongModel) ->
         return False
 
 
+def mp3_tag_reader(mp3_path: str) -> Optional[itunes_api.ItunesApiSongModel]:
+    """Read ID3 tags from an MP3 file and return as ItunesApiSongModel.
+
+    Args:
+        mp3_path (str): path to the mp3 file
+
+    Returns:
+        ItunesApiSongModel if tags could be read, None otherwise
+    """
+    try:
+        audiofile = eyed3.load(mp3_path)
+        if audiofile is None or audiofile.tag is None:
+            return None
+        tag = audiofile.tag
+        track_num, track_count = tag.track_num or (0, 0)
+        disc_num, disc_count = tag.disc_num or (1, 1)
+        return itunes_api.ItunesApiSongModel(
+            trackName=tag.title or "",
+            artistName=tag.artist or "",
+            collectionName=tag.album or "",
+            artworkUrl100="",
+            primaryGenreName=tag.genre.name if tag.genre else "",
+            trackNumber=track_num or 0,
+            trackCount=track_count or 0,
+            collectionArtistName=tag.album_artist or "",
+            discNumber=disc_num or 1,
+            discCount=disc_count or 1,
+            releaseDate=str(tag.recording_date) if tag.recording_date else "",
+        )
+    except Exception as e:
+        logger.exception(f"Error reading MP3 tags from {mp3_path}: {e}")
+        return None
+
+
+def m4a_tag_reader(m4a_path: str) -> Optional[itunes_api.ItunesApiSongModel]:
+    """Read tags from an M4A file and return as ItunesApiSongModel.
+
+    Args:
+        m4a_path (str): path to the m4a file
+
+    Returns:
+        ItunesApiSongModel if tags could be read, None otherwise
+    """
+    try:
+        audiofile = MP4(m4a_path)
+        tags = audiofile.tags or {}
+
+        def _get(key: str, default: str = "") -> str:
+            val = tags.get(key)
+            return str(val[0]) if val else default
+
+        trkn = tags.get("trkn", [(0, 0)])[0]
+        disk = tags.get("disk", [(1, 1)])[0]
+        return itunes_api.ItunesApiSongModel(
+            trackName=_get("\xa9nam"),
+            artistName=_get("\xa9ART"),
+            collectionName=_get("\xa9alb"),
+            artworkUrl100="",
+            primaryGenreName=_get("\xa9gen"),
+            trackNumber=trkn[0] if trkn else 0,
+            trackCount=trkn[1] if trkn else 0,
+            collectionArtistName=_get("aART"),
+            discNumber=disk[0] if disk else 1,
+            discCount=disk[1] if disk else 1,
+            releaseDate=_get("\xa9day"),
+        )
+    except Exception as e:
+        logger.exception(f"Error reading M4A tags from {m4a_path}: {e}")
+        return None
+
+
 def query_api(
     search_variable: str, limit: int, mode: modes.Modes, lookup: bool = False
 ) -> List[Union[itunes_api.ItunesApiSongModel, itunes_api.ItunesApiAlbumKeys]]:

--- a/songbirdcore/itunes.py
+++ b/songbirdcore/itunes.py
@@ -181,7 +181,9 @@ def mp3ID3Tagger(mp3_path: str, song_tag_data: itunes_api.ItunesApiSongModel) ->
         return False
 
 
-def m4aID3TaggerNoArtwork(file_path: str, song_tag_data: itunes_api.ItunesApiSongModel) -> bool:
+def m4aID3TaggerNoArtwork(
+    file_path: str, song_tag_data: itunes_api.ItunesApiSongModel
+) -> bool:
     """Tag an m4a file with metadata only — no artwork fetch."""
     try:
         logger.info(f"Adding tags (no artwork) to m4a file: {file_path}")
@@ -199,11 +201,15 @@ def m4aID3TaggerNoArtwork(file_path: str, song_tag_data: itunes_api.ItunesApiSon
         logger.info("Your tags have been set.")
         return True
     except Exception as e:
-        logger.exception(f"Unexpected error occured while trying to tag your m4a file: {e}")
+        logger.exception(
+            f"Unexpected error occured while trying to tag your m4a file: {e}"
+        )
         return False
 
 
-def mp3ID3TaggerNoArtwork(mp3_path: str, song_tag_data: itunes_api.ItunesApiSongModel) -> bool:
+def mp3ID3TaggerNoArtwork(
+    mp3_path: str, song_tag_data: itunes_api.ItunesApiSongModel
+) -> bool:
     """Tag an mp3 file with metadata only — no artwork fetch."""
     try:
         logger.info(f"Adding tags (no artwork) to mp3 file: {mp3_path}")
@@ -221,11 +227,15 @@ def mp3ID3TaggerNoArtwork(mp3_path: str, song_tag_data: itunes_api.ItunesApiSong
         logger.info("Your tags have been set.")
         return True
     except Exception as e:
-        logger.exception(f"Unexpected error occured while trying to tag your mp3 file: {e}")
+        logger.exception(
+            f"Unexpected error occured while trying to tag your mp3 file: {e}"
+        )
         return False
 
 
-def mp3_tag_reader(mp3_path: str) -> tuple[Optional[itunes_api.ItunesApiSongModel], Optional[bytes]]:
+def mp3_tag_reader(
+    mp3_path: str,
+) -> tuple[Optional[itunes_api.ItunesApiSongModel], Optional[bytes]]:
     """Read ID3 tags and embedded artwork from an MP3 file.
 
     Returns:
@@ -251,14 +261,18 @@ def mp3_tag_reader(mp3_path: str) -> tuple[Optional[itunes_api.ItunesApiSongMode
             discCount=disc_count or 1,
             releaseDate=str(tag.recording_date) if tag.recording_date else "",
         )
-        artwork_bytes = next((img.image_data for img in tag.images if img.image_data), None)
+        artwork_bytes = next(
+            (img.image_data for img in tag.images if img.image_data), None
+        )
         return model, artwork_bytes
     except Exception as e:
         logger.exception(f"Error reading MP3 tags from {mp3_path}: {e}")
         return None, None
 
 
-def m4a_tag_reader(m4a_path: str) -> tuple[Optional[itunes_api.ItunesApiSongModel], Optional[bytes]]:
+def m4a_tag_reader(
+    m4a_path: str,
+) -> tuple[Optional[itunes_api.ItunesApiSongModel], Optional[bytes]]:
     """Read tags and embedded artwork from an M4A file.
 
     Returns:

--- a/songbirdcore/itunes.py
+++ b/songbirdcore/itunes.py
@@ -181,6 +181,50 @@ def mp3ID3Tagger(mp3_path: str, song_tag_data: itunes_api.ItunesApiSongModel) ->
         return False
 
 
+def m4aID3TaggerNoArtwork(file_path: str, song_tag_data: itunes_api.ItunesApiSongModel) -> bool:
+    """Tag an m4a file with metadata only — no artwork fetch."""
+    try:
+        logger.info(f"Adding tags (no artwork) to m4a file: {file_path}")
+        audiofile = MP4(file_path)
+        audiofile["\xa9ART"] = song_tag_data.artistName
+        audiofile["\xa9alb"] = song_tag_data.collectionName
+        audiofile["\xa9nam"] = song_tag_data.trackName
+        audiofile["\xa9gen"] = song_tag_data.primaryGenreName
+        audiofile["trkn"] = [(song_tag_data.trackNumber, song_tag_data.trackCount)]
+        audiofile["disk"] = [(song_tag_data.discNumber, song_tag_data.discCount)]
+        audiofile["\xa9day"] = song_tag_data.releaseDate
+        if song_tag_data.collectionArtistName is not None:
+            audiofile["aART"] = song_tag_data.collectionArtistName
+        audiofile.save()
+        logger.info("Your tags have been set.")
+        return True
+    except Exception as e:
+        logger.exception(f"Unexpected error occured while trying to tag your m4a file: {e}")
+        return False
+
+
+def mp3ID3TaggerNoArtwork(mp3_path: str, song_tag_data: itunes_api.ItunesApiSongModel) -> bool:
+    """Tag an mp3 file with metadata only — no artwork fetch."""
+    try:
+        logger.info(f"Adding tags (no artwork) to mp3 file: {mp3_path}")
+        audiofile = eyed3.load(mp3_path)
+        audiofile.tag.artist = song_tag_data.artistName
+        audiofile.tag.album = song_tag_data.collectionName
+        audiofile.tag.title = song_tag_data.trackName
+        audiofile.tag.genre = song_tag_data.primaryGenreName
+        audiofile.tag.track_num = (song_tag_data.trackNumber, song_tag_data.trackCount)
+        audiofile.tag.disc_num = (song_tag_data.discNumber, song_tag_data.discCount)
+        audiofile.tag.recording_date = song_tag_data.releaseDate
+        if song_tag_data.collectionArtistName is not None:
+            audiofile.tag.album_artist = song_tag_data.collectionArtistName
+        audiofile.tag.save()
+        logger.info("Your tags have been set.")
+        return True
+    except Exception as e:
+        logger.exception(f"Unexpected error occured while trying to tag your mp3 file: {e}")
+        return False
+
+
 def mp3_tag_reader(mp3_path: str) -> tuple[Optional[itunes_api.ItunesApiSongModel], Optional[bytes]]:
     """Read ID3 tags and embedded artwork from an MP3 file.
 

--- a/songbirdcore/itunes.py
+++ b/songbirdcore/itunes.py
@@ -181,23 +181,20 @@ def mp3ID3Tagger(mp3_path: str, song_tag_data: itunes_api.ItunesApiSongModel) ->
         return False
 
 
-def mp3_tag_reader(mp3_path: str) -> Optional[itunes_api.ItunesApiSongModel]:
-    """Read ID3 tags from an MP3 file and return as ItunesApiSongModel.
-
-    Args:
-        mp3_path (str): path to the mp3 file
+def mp3_tag_reader(mp3_path: str) -> tuple[Optional[itunes_api.ItunesApiSongModel], Optional[bytes]]:
+    """Read ID3 tags and embedded artwork from an MP3 file.
 
     Returns:
-        ItunesApiSongModel if tags could be read, None otherwise
+        (ItunesApiSongModel or None, artwork bytes or None)
     """
     try:
         audiofile = eyed3.load(mp3_path)
         if audiofile is None or audiofile.tag is None:
-            return None
+            return None, None
         tag = audiofile.tag
         track_num, track_count = tag.track_num or (0, 0)
         disc_num, disc_count = tag.disc_num or (1, 1)
-        return itunes_api.ItunesApiSongModel(
+        model = itunes_api.ItunesApiSongModel(
             trackName=tag.title or "",
             artistName=tag.artist or "",
             collectionName=tag.album or "",
@@ -210,19 +207,18 @@ def mp3_tag_reader(mp3_path: str) -> Optional[itunes_api.ItunesApiSongModel]:
             discCount=disc_count or 1,
             releaseDate=str(tag.recording_date) if tag.recording_date else "",
         )
+        artwork_bytes = next((img.image_data for img in tag.images if img.image_data), None)
+        return model, artwork_bytes
     except Exception as e:
         logger.exception(f"Error reading MP3 tags from {mp3_path}: {e}")
-        return None
+        return None, None
 
 
-def m4a_tag_reader(m4a_path: str) -> Optional[itunes_api.ItunesApiSongModel]:
-    """Read tags from an M4A file and return as ItunesApiSongModel.
-
-    Args:
-        m4a_path (str): path to the m4a file
+def m4a_tag_reader(m4a_path: str) -> tuple[Optional[itunes_api.ItunesApiSongModel], Optional[bytes]]:
+    """Read tags and embedded artwork from an M4A file.
 
     Returns:
-        ItunesApiSongModel if tags could be read, None otherwise
+        (ItunesApiSongModel or None, artwork bytes or None)
     """
     try:
         audiofile = MP4(m4a_path)
@@ -234,7 +230,7 @@ def m4a_tag_reader(m4a_path: str) -> Optional[itunes_api.ItunesApiSongModel]:
 
         trkn = tags.get("trkn", [(0, 0)])[0]
         disk = tags.get("disk", [(1, 1)])[0]
-        return itunes_api.ItunesApiSongModel(
+        model = itunes_api.ItunesApiSongModel(
             trackName=_get("\xa9nam"),
             artistName=_get("\xa9ART"),
             collectionName=_get("\xa9alb"),
@@ -247,9 +243,12 @@ def m4a_tag_reader(m4a_path: str) -> Optional[itunes_api.ItunesApiSongModel]:
             discCount=disk[1] if disk else 1,
             releaseDate=_get("\xa9day"),
         )
+        covers = tags.get("covr", [])
+        artwork_bytes = bytes(covers[0]) if covers else None
+        return model, artwork_bytes
     except Exception as e:
         logger.exception(f"Error reading M4A tags from {m4a_path}: {e}")
-        return None
+        return None, None
 
 
 def query_api(

--- a/tests/unit/test_itunes.py
+++ b/tests/unit/test_itunes.py
@@ -123,11 +123,11 @@ def test_mp3_tag_reader(create_test_folder, query_api):
     shutil.copy(input_fpath, output_fpath)
     tags = query_api[0]
     itunes.mp3ID3Tagger(mp3_path=output_fpath, song_tag_data=tags)
-    result = itunes.mp3_tag_reader(output_fpath)
-    assert result is not None
-    assert result.trackName == tags.trackName
-    assert result.artistName == tags.artistName
-    assert result.collectionName == tags.collectionName
+    model, artwork_bytes = itunes.mp3_tag_reader(output_fpath)
+    assert model is not None
+    assert model.trackName == tags.trackName
+    assert model.artistName == tags.artistName
+    assert model.collectionName == tags.collectionName
 
 
 def test_m4a_tag_reader(create_test_folder, query_api):
@@ -137,8 +137,8 @@ def test_m4a_tag_reader(create_test_folder, query_api):
     shutil.copy(input_fpath, output_fpath)
     tags = query_api[0]
     itunes.m4a_tagger(file_path=output_fpath, song_tag_data=tags)
-    result = itunes.m4a_tag_reader(output_fpath)
-    assert result is not None
-    assert result.trackName == tags.trackName
-    assert result.artistName == tags.artistName
-    assert result.collectionName == tags.collectionName
+    model, artwork_bytes = itunes.m4a_tag_reader(output_fpath)
+    assert model is not None
+    assert model.trackName == tags.trackName
+    assert model.artistName == tags.artistName
+    assert model.collectionName == tags.collectionName

--- a/tests/unit/test_itunes.py
+++ b/tests/unit/test_itunes.py
@@ -114,3 +114,31 @@ def test_artwork_searcher(query_api):
     """test getting artwork url given song properties"""
     response = itunes.artwork_searcher(url=query_api[0].artworkUrl100)
     assert response.status_code == 200
+
+
+def test_mp3_tag_reader(create_test_folder, query_api):
+    """round-trip: tag an mp3 then read tags back"""
+    input_fpath = os.path.join(sys.path[0], RESOURCES_FOLDER, "empty.mp3")
+    output_fpath = os.path.join(create_test_folder, "empty.mp3")
+    shutil.copy(input_fpath, output_fpath)
+    tags = query_api[0]
+    itunes.mp3ID3Tagger(mp3_path=output_fpath, song_tag_data=tags)
+    result = itunes.mp3_tag_reader(output_fpath)
+    assert result is not None
+    assert result.trackName == tags.trackName
+    assert result.artistName == tags.artistName
+    assert result.collectionName == tags.collectionName
+
+
+def test_m4a_tag_reader(create_test_folder, query_api):
+    """round-trip: tag an m4a then read tags back"""
+    input_fpath = os.path.join(sys.path[0], RESOURCES_FOLDER, "empty.m4a")
+    output_fpath = os.path.join(create_test_folder, "empty.m4a")
+    shutil.copy(input_fpath, output_fpath)
+    tags = query_api[0]
+    itunes.m4a_tagger(file_path=output_fpath, song_tag_data=tags)
+    result = itunes.m4a_tag_reader(output_fpath)
+    assert result is not None
+    assert result.trackName == tags.trackName
+    assert result.artistName == tags.artistName
+    assert result.collectionName == tags.collectionName

--- a/tests/unit/test_itunes.py
+++ b/tests/unit/test_itunes.py
@@ -116,29 +116,62 @@ def test_artwork_searcher(query_api):
     assert response.status_code == 200
 
 
+def _assert_round_trip(model, tags):
+    assert model is not None
+    assert model.trackName == tags.trackName
+    assert model.artistName == tags.artistName
+    assert model.collectionName == tags.collectionName
+    assert model.primaryGenreName == tags.primaryGenreName
+    assert model.trackNumber == tags.trackNumber
+    assert model.trackCount == tags.trackCount
+    assert model.discNumber == tags.discNumber
+    assert model.discCount == tags.discCount
+    assert model.collectionArtistName == tags.collectionArtistName
+
+
 def test_mp3_tag_reader(create_test_folder, query_api):
-    """round-trip: tag an mp3 then read tags back"""
+    """round-trip: tag an mp3 (with artwork) then read tags back"""
     input_fpath = os.path.join(sys.path[0], RESOURCES_FOLDER, "empty.mp3")
     output_fpath = os.path.join(create_test_folder, "empty.mp3")
     shutil.copy(input_fpath, output_fpath)
     tags = query_api[0]
     itunes.mp3ID3Tagger(mp3_path=output_fpath, song_tag_data=tags)
     model, artwork_bytes = itunes.mp3_tag_reader(output_fpath)
-    assert model is not None
-    assert model.trackName == tags.trackName
-    assert model.artistName == tags.artistName
-    assert model.collectionName == tags.collectionName
+    _assert_round_trip(model, tags)
+    assert artwork_bytes is not None and len(artwork_bytes) > 0
 
 
 def test_m4a_tag_reader(create_test_folder, query_api):
-    """round-trip: tag an m4a then read tags back"""
+    """round-trip: tag an m4a (with artwork) then read tags back"""
     input_fpath = os.path.join(sys.path[0], RESOURCES_FOLDER, "empty.m4a")
     output_fpath = os.path.join(create_test_folder, "empty.m4a")
     shutil.copy(input_fpath, output_fpath)
     tags = query_api[0]
     itunes.m4a_tagger(file_path=output_fpath, song_tag_data=tags)
     model, artwork_bytes = itunes.m4a_tag_reader(output_fpath)
-    assert model is not None
-    assert model.trackName == tags.trackName
-    assert model.artistName == tags.artistName
-    assert model.collectionName == tags.collectionName
+    _assert_round_trip(model, tags)
+    assert artwork_bytes is not None and len(artwork_bytes) > 0
+
+
+def test_mp3_no_artwork_tagger_round_trip(create_test_folder, query_api):
+    """mp3ID3TaggerNoArtwork: tag without artwork, reader returns no artwork"""
+    input_fpath = os.path.join(sys.path[0], RESOURCES_FOLDER, "empty.mp3")
+    output_fpath = os.path.join(create_test_folder, "empty.mp3")
+    shutil.copy(input_fpath, output_fpath)
+    tags = query_api[0]
+    assert itunes.mp3ID3TaggerNoArtwork(mp3_path=output_fpath, song_tag_data=tags)
+    model, artwork_bytes = itunes.mp3_tag_reader(output_fpath)
+    _assert_round_trip(model, tags)
+    assert artwork_bytes is None
+
+
+def test_m4a_no_artwork_tagger_round_trip(create_test_folder, query_api):
+    """m4aID3TaggerNoArtwork: tag without artwork, reader returns no artwork"""
+    input_fpath = os.path.join(sys.path[0], RESOURCES_FOLDER, "empty.m4a")
+    output_fpath = os.path.join(create_test_folder, "empty.m4a")
+    shutil.copy(input_fpath, output_fpath)
+    tags = query_api[0]
+    assert itunes.m4aID3TaggerNoArtwork(file_path=output_fpath, song_tag_data=tags)
+    model, artwork_bytes = itunes.m4a_tag_reader(output_fpath)
+    _assert_round_trip(model, tags)
+    assert artwork_bytes is None


### PR DESCRIPTION
## Summary
- Adds \`mp3_tag_reader(mp3_path)\` — reads ID3 tags from MP3 via eyed3, returns \`ItunesApiSongModel\`
- Adds \`m4a_tag_reader(m4a_path)\` — reads tags from M4A via mutagen MP4, returns \`ItunesApiSongModel\`
- Both return \`None\` on failure (untagged file, missing file, parse error)
- \`artworkUrl100\` is set to \`""\` since artwork is stored as binary in the file, not as a URL

## Test plan
- [ ] \`test_mp3_tag_reader\` — tag empty.mp3, read back, verify round-trip
- [ ] \`test_m4a_tag_reader\` — same for empty.m4a
- [ ] \`make test\` passes