### PR TITLE
chore: bump 0.1.8 -> 0.1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdcore"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.1.8"
+version = "0.1.9"
 description = "core low level api for songbird"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdcore/version.py
+++ b/songbirdcore/version.py
@@ -1,1 +1,1 @@
-version = "0.1.8"
+version = "0.1.9"


### PR DESCRIPTION
## Summary
- Bumps version for the tag-readers feature merged in #21
- Required because PyPI rejected republishing 0.1.8

## Test plan
- [x] Versions match in pyproject.toml and version.py